### PR TITLE
Fix branch constraints on the github workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,8 +1,6 @@
 name: audit with tests and lint
 on:
   push:
-    branches:
-      - main
     paths-ignore:
       - '**.md'
   pull_request:


### PR DESCRIPTION
This PR intends to remove the constraints of the github actions where it was only triggered on the `main` branch - now defaulted to all branches