### PR TITLE
feat(migrations): Add YoYo managed migrations.

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -4,8 +4,6 @@ from dependency_injector.wiring import Provide
 
 from app import pony_db
 from app.modules import roles_management, rubber_duck
-# noinspection PyUnresolvedReferences
-# from app.modules.models import sql  # import sql to make generate_mapping work
 from app.transport import Discord
 from app.usecases import Roles, RubberDuck
 
@@ -13,8 +11,8 @@ from app.usecases import Roles, RubberDuck
 def _setup_pony(
         provider: str,
         filename: str,
-        create_db: bool = True,
-        create_tables: bool = True,
+        create_db: bool = False,
+        create_tables: bool = False,
 ) -> None:
     pony_db.bind(provider=provider, filename=filename, create_db=create_db)
     pony_db.generate_mapping(create_tables=create_tables)

--- a/migrations/20210320_01_301F6-initial-migration.py
+++ b/migrations/20210320_01_301F6-initial-migration.py
@@ -1,0 +1,16 @@
+"""
+Initial migration
+"""
+
+from yoyo import step
+
+__depends__ = {}
+
+steps = [
+    step("""create table RubberDuck (
+        id      INTEGER
+        primary key autoincrement,
+        user_id BIGINT not null
+    )""",
+         "DROP TABLE RubberDuck")
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 environs==9.3.1
 discord==1.0.1
 dependency_injector==4.29.2
-pony
+yoyo-migrations==7.3.1
+pony==0.7.14
+

--- a/yoyo.ini
+++ b/yoyo.ini
@@ -1,0 +1,7 @@
+[DEFAULT]
+sources = ./migrations
+migration_table = _yoyo_migration
+batch_mode = off
+verbosity = 0
+editor = nano {}
+database = sqlite:///local.sqlite


### PR DESCRIPTION
Pony ORM does not provide any migration tools yet.
I did not wished to use alembic without sqlalchemy cause it is
far too heavy for me, so I choose to try YoYo witch seems lighter.

Main issue of YoYo vs Alambic is the use of SQL queries so it cannot
transition to other database without a rewrite.